### PR TITLE
tidy-related fixes

### DIFF
--- a/wisp.cpp
+++ b/wisp.cpp
@@ -126,11 +126,11 @@ public:
     // have this atom in scope?
     // This is only used to determine which atoms to capture when
     // creating a lambda function.
-    bool has(std::string name) const;
+    bool has(const std::string& name) const;
     // Get the value associated with this name in this scope
-    Value get(std::string name) const;
+    Value get(const std::string& name) const;
     // Set the value associated with this name in this scope
-    void set(std::string name, Value value);
+    void set(const std::string& name, Value value);
 
     void combine(Environment const &other);
 
@@ -187,7 +187,7 @@ public:
     Value(std::vector<Value> list) : type(LIST), list(list) {}
 
     // Construct a quoted value
-    static Value quote(Value quoted) {
+    static Value quote(const Value& quoted) {
         Value result;
         result.type = QUOTE;
 
@@ -332,7 +332,7 @@ public:
     }
 
     // Push an item to the end of this list
-    void push(Value val) {
+    void push(const Value& val) {
         // If this item is not a list, you cannot push to it.
         // Throw an error.
         if (type != LIST)
@@ -444,19 +444,19 @@ public:
     /// ORDERING OPERATIONS ////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////////
 
-    bool operator>=(Value other) const {
+    bool operator>=(const Value& other) const {
         return !(*this < other);
     }
 
-    bool operator<=(Value other) const {
+    bool operator<=(const Value& other) const {
         return (*this == other) || (*this < other);
     }
 
-    bool operator>(Value other) const {
+    bool operator>(const Value& other) const {
         return !(*this <= other);
     }
 
-    bool operator<(Value other) const {
+    bool operator<(const Value& other) const {
         // Other type must be a float or an int
         if (other.type != FLOAT && other.type != INT)
             throw Error(*this, Environment(), INVALID_BIN_OP);
@@ -826,7 +826,7 @@ std::ostream &operator<<(std::ostream &os, Environment const &e) {
     return os << "}";
 }
 
-void Environment::set(std::string name, Value value) {
+void Environment::set(const std::string& name, Value value) {
     defs[name] = value;
 }
 
@@ -1680,7 +1680,7 @@ void repl(Environment &env) {
 }
 
 // Does this environment, or its parent environment, have a variable?
-bool Environment::has(std::string name) const {
+bool Environment::has(const std::string& name) const {
     // Find the value in the map
     std::map<std::string, Value>::const_iterator itr = defs.find(name);
     if (itr != defs.end())
@@ -1694,7 +1694,7 @@ bool Environment::has(std::string name) const {
 }
 
 // Get the value associated with this name in this scope
-Value Environment::get(std::string name) const {
+Value Environment::get(const std::string& name) const {
     // Meta operations
     if (name == "eval")  return Value("eval",  builtin::eval);
     if (name == "type")  return Value("type",  builtin::get_type_name);

--- a/wisp.cpp
+++ b/wisp.cpp
@@ -809,7 +809,7 @@ std::string Error::description() {
 void Environment::combine(Environment const &other) {
     // Normally, I would use the `insert` method of the `map` class,
     // but it doesn't overwrite previously declared values for keys.
-    std::map<std::string, Value>::const_iterator itr = other.defs.begin();
+    auto itr = other.defs.begin();
     for (; itr!=other.defs.end(); itr++) {
         // Iterate through the keys and assign each value.
         defs[itr->first] = itr->second;
@@ -817,7 +817,7 @@ void Environment::combine(Environment const &other) {
 }
 
 std::ostream &operator<<(std::ostream &os, Environment const &e) {
-    std::map<std::string, Value>::const_iterator itr = e.defs.begin();
+    auto itr = e.defs.begin();
     os << "{ ";
     for (; itr != e.defs.end(); itr++) {
         os << '\'' << itr->first << "' : " << itr->second.debug() << ", ";
@@ -1681,7 +1681,7 @@ void repl(Environment &env) {
 // Does this environment, or its parent environment, have a variable?
 bool Environment::has(const std::string& name) const {
     // Find the value in the map
-    std::map<std::string, Value>::const_iterator itr = defs.find(name);
+    auto itr = defs.find(name);
     if (itr != defs.end())
         // If it was found
         return true;
@@ -1770,7 +1770,7 @@ Value Environment::get(const std::string& name) const {
     // Constants
     if (name == "endl") return Value::string("\n");
 
-    std::map<std::string, Value>::const_iterator itr = defs.find(name);
+    auto itr = defs.find(name);
     if (itr != defs.end()) return itr->second;
     else if (parent_scope != nullptr) {
         itr = parent_scope->defs.find(name);

--- a/wisp.cpp
+++ b/wisp.cpp
@@ -226,10 +226,10 @@ public:
 
         // Lambdas capture only variables that they know they will use.
         std::vector<std::string> used_atoms = ret.get_used_atoms();
-        for (size_t i=0; i<used_atoms.size(); i++) {
+        for (auto & used_atom : used_atoms) {
             // If the environment has a symbol that this lambda uses, capture it.
-            if (env.has(used_atoms[i]))
-                lambda_scope.set(used_atoms[i], env.get(used_atoms[i]));
+            if (env.has(used_atom))
+                lambda_scope.set(used_atom, env.get(used_atom));
         }
     }
 
@@ -266,9 +266,9 @@ public:
             case LIST:
                 // If this is a list, add each of the atoms used in all
                 // of the elements in the list.
-                for (size_t i=0; i<list.size(); i++) {
+                for (auto & i : list) {
                     // Get the atoms used in the element
-                    tmp = list[i].get_used_atoms();
+                    tmp = i.get_used_atoms();
                     // Add the used atoms to the current list of used atoms
                     result.insert(result.end(), tmp.begin(), tmp.end());
                 }
@@ -517,8 +517,8 @@ public:
                     // Maintain the value that will be returned
                     Value result = *this;
                     // Add each item in the other list to the end of this list
-                    for (size_t i=0; i<other.list.size(); i++)
-                        result.push(other.list[i]);
+                    for (auto & i : other.list)
+                        result.push(i);
                     return result;
 
                 } else throw Error(*this, Environment(), INVALID_BIN_OP);
@@ -733,9 +733,9 @@ public:
             case FLOAT:
                 return to_string(stack_data.f);
             case STRING:
-                for (size_t i=0; i<str.length(); i++) {
-                    if (str[i] == '"') result += "\\\"";
-                    else result.push_back(str[i]);
+                for (char i : str) {
+                    if (i == '"') result += "\\\"";
+                    else result.push_back(i);
                 }
                 return "\"" + result + "\"";
             case LAMBDA:
@@ -893,8 +893,8 @@ Value Value::eval(Environment &env) {
             function = list[0].eval(env);
 
             if (!function.is_builtin())
-                for (size_t i=0; i<args.size(); i++)
-                    args[i] = args[i].eval(env);
+                for (auto & arg : args)
+                    arg = arg.eval(env);
 
             return function.apply(
                     args,
@@ -1052,8 +1052,8 @@ namespace builtin {
     // their arguments. To make a regular builtin that evaluates its
     // arguments, we just call this function in our builtin definition.
     void eval_args(std::vector<Value> &args, Environment &env) {
-        for (size_t i=0; i<args.size(); i++)
-            args[i] = args[i].eval(env);
+        for (auto & arg : args)
+            arg = arg.eval(env);
     }
 
     // Create a lambda function (SPECIAL FORM)
@@ -1115,8 +1115,8 @@ namespace builtin {
         Value acc;
         std::vector<Value> list = args[1].eval(env).as_list();
 
-        for (size_t i=0; i<list.size(); i++) {
-            env.set(args[0].as_atom(), list[i]);
+        for (auto & i : list) {
+            env.set(args[0].as_atom(), i);
 
             for (size_t j=1; j<args.size()-1; j++)
                 args[j].eval(env);
@@ -1129,8 +1129,8 @@ namespace builtin {
     // Evaluate a block of expressions in the current environment (SPECIAL FORM)
     Value do_block(std::vector<Value> args, Environment &env) {
         Value acc;
-        for (size_t i=0; i<args.size(); i++)
-            acc = args[i].eval(env);
+        for (auto & arg : args)
+            acc = arg.eval(env);
         return acc;
     }
 
@@ -1138,16 +1138,16 @@ namespace builtin {
     Value scope(std::vector<Value> args, Environment &env) {
         Environment e = env;
         Value acc;
-        for (size_t i=0; i<args.size(); i++)
-            acc = args[i].eval(e);
+        for (auto & arg : args)
+            acc = arg.eval(e);
         return acc;
     }
 
     // Quote an expression (SPECIAL FORM)
     Value quote(std::vector<Value> args, Environment &env) {
         std::vector<Value> v;
-        for (size_t i=0; i<args.size(); i++)
-            v.push_back(args[i]);
+        for (const auto & arg : args)
+            v.push_back(arg);
         return Value(v);
     }
 
@@ -1585,8 +1585,8 @@ namespace builtin {
         eval_args(args, env);
 
         std::vector<Value> result, l=args[1].as_list(), tmp;
-        for (size_t i=0; i<l.size(); i++) {
-            tmp.push_back(l[i]);
+        for (const auto & i : l) {
+            tmp.push_back(i);
             result.push_back(args[0].apply(tmp, env));
             tmp.clear();
         }
@@ -1598,10 +1598,10 @@ namespace builtin {
         eval_args(args, env);
 
         std::vector<Value> result, l=args[1].as_list(), tmp;
-        for (size_t i=0; i<l.size(); i++) {
-            tmp.push_back(l[i]);
+        for (const auto & i : l) {
+            tmp.push_back(i);
             if (args[0].apply(tmp, env).as_bool())
-                result.push_back(l[i]);
+                result.push_back(i);
             tmp.clear();
         }
         return Value(result);
@@ -1613,9 +1613,9 @@ namespace builtin {
 
         std::vector<Value> l=args[2].as_list(), tmp;
         Value acc = args[1];
-        for (size_t i=0; i<l.size(); i++) {
+        for (const auto & i : l) {
             tmp.push_back(acc);
-            tmp.push_back(l[i]);
+            tmp.push_back(i);
             acc = args[0].apply(tmp, env);
             tmp.clear();
         }

--- a/wisp.cpp
+++ b/wisp.cpp
@@ -149,14 +149,13 @@ private:
 
 
 // An exception thrown by the lisp
-class Error {
+class Error : std::exception {
 public:
     // Create an error with the value that caused the error,
     // the scope where the error was found, and the message.
     Error(Value v, Environment const &env, const char *msg);
     // Copy constructor is needed to prevent double frees
     Error(Error const &other);
-    ~Error();
 
     // Get the printable error description.
     std::string description();
@@ -198,7 +197,7 @@ public:
     }
 
     // Construct an atom
-    static Value atom(std::string s) {
+    static Value atom(const std::string& s) {
         Value result;
         result.type = ATOM;
 
@@ -208,7 +207,7 @@ public:
     }
 
     // Construct a string
-    static Value string(std::string s) {
+    static Value string(const std::string& s) {
         Value result;
         result.type = STRING;
 
@@ -234,7 +233,7 @@ public:
     }
 
     // Construct a builtin function
-    Value(std::string name, Builtin b) : type(BUILTIN) {
+    Value(const std::string& name, Builtin b) : type(BUILTIN) {
         // Store the name of the builtin function in the str member
         // to save memory, and use the builtin function slot in the union
         // to store the function pointer.

--- a/wisp.cpp
+++ b/wisp.cpp
@@ -120,7 +120,7 @@ class Value;
 class Environment {
 public:
     // Default constructor
-    Environment() : parent_scope(NULL) {}
+    Environment() : parent_scope(nullptr) {}
 
     // Does this environment, or its parent environment,
     // have this atom in scope?
@@ -1686,7 +1686,7 @@ bool Environment::has(std::string name) const {
     if (itr != defs.end())
         // If it was found
         return true;
-    else if (parent_scope != NULL)
+    else if (parent_scope != nullptr)
         // If it was not found in the current environment,
         // try to find it in the parent environment
         return parent_scope->has(name);
@@ -1773,7 +1773,7 @@ Value Environment::get(std::string name) const {
 
     std::map<std::string, Value>::const_iterator itr = defs.find(name);
     if (itr != defs.end()) return itr->second;
-    else if (parent_scope != NULL) {
+    else if (parent_scope != nullptr) {
         itr = parent_scope->defs.find(name);
         if (itr != parent_scope->defs.end()) return itr->second;
         else return parent_scope->get(name);
@@ -1790,7 +1790,7 @@ int main(int argc, const char **argv) {
     env.set("cmd-args", Value(args));
 
 #ifdef USE_STD
-    srand(time(NULL));
+    srand(time(nullptr));
     try {
         if (argc == 1 || (argc == 2 && std::string(argv[1]) == "-i"))
             repl(env);

--- a/wisp.cpp
+++ b/wisp.cpp
@@ -95,7 +95,7 @@ std::string read_file_contents(const std::string& filename) {
 #define to_string( x ) static_cast<std::ostringstream&>((std::ostringstream() << std::dec << x )).str()
 
 // Replace a substring with a replacement string in a source string
-void replace_substring(std::string &src, const std::string& substr, std::string replacement) {
+void replace_substring(std::string &src, const std::string& substr, const std::string& replacement) {
     size_t i=0;
     for (i=src.find(substr, i); i!=std::string::npos; i=src.find(substr, i)) {
         src.replace(i, substr.size(), replacement);
@@ -126,11 +126,11 @@ public:
     // have this atom in scope?
     // This is only used to determine which atoms to capture when
     // creating a lambda function.
-    bool has(const std::string& name) const;
+    bool has(std::string name) const;
     // Get the value associated with this name in this scope
-    Value get(const std::string& name) const;
+    Value get(std::string name) const;
     // Set the value associated with this name in this scope
-    void set(const std::string& name, Value value);
+    void set(std::string name, Value value);
 
     void combine(Environment const &other);
 
@@ -187,7 +187,7 @@ public:
     Value(std::vector<Value> list) : type(LIST), list(list) {}
 
     // Construct a quoted value
-    static Value quote(const Value& quoted) {
+    static Value quote(Value quoted) {
         Value result;
         result.type = QUOTE;
 
@@ -332,7 +332,7 @@ public:
     }
 
     // Push an item to the end of this list
-    void push(const Value& val) {
+    void push(Value val) {
         // If this item is not a list, you cannot push to it.
         // Throw an error.
         if (type != LIST)
@@ -448,7 +448,7 @@ public:
         return !(*this < other);
     }
 
-    bool operator<=(const Value& other) const {
+    bool operator<=(Value other) const {
         return (*this == other) || (*this < other);
     }
 
@@ -456,7 +456,7 @@ public:
         return !(*this <= other);
     }
 
-    bool operator<(const Value& other) const {
+    bool operator<(Value other) const {
         // Other type must be a float or an int
         if (other.type != FLOAT && other.type != INT)
             throw Error(*this, Environment(), INVALID_BIN_OP);
@@ -826,7 +826,7 @@ std::ostream &operator<<(std::ostream &os, Environment const &e) {
     return os << "}";
 }
 
-void Environment::set(const std::string& name, Value value) {
+void Environment::set(std::string name, Value value) {
     defs[name] = value;
 }
 
@@ -1680,7 +1680,7 @@ void repl(Environment &env) {
 }
 
 // Does this environment, or its parent environment, have a variable?
-bool Environment::has(const std::string& name) const {
+bool Environment::has(std::string name) const {
     // Find the value in the map
     std::map<std::string, Value>::const_iterator itr = defs.find(name);
     if (itr != defs.end())
@@ -1694,7 +1694,7 @@ bool Environment::has(const std::string& name) const {
 }
 
 // Get the value associated with this name in this scope
-Value Environment::get(const std::string& name) const {
+Value Environment::get(std::string name) const {
     // Meta operations
     if (name == "eval")  return Value("eval",  builtin::eval);
     if (name == "type")  return Value("type",  builtin::get_type_name);

--- a/wisp.cpp
+++ b/wisp.cpp
@@ -882,7 +882,7 @@ Value Value::eval(Environment &env) {
         case ATOM:
             return env.get(str);
         case LIST:
-            if (list.size() < 1)
+            if (list.empty())
                 throw Error(*this, env, EVAL_EMPTY_LIST);
 
             args = std::vector<Value>(list.begin() + 1, list.end());
@@ -922,12 +922,12 @@ Value parse(std::string &s, int &ptr) {
         s.erase(ptr, save_ptr - ptr);
         skip_whitespace(s, ptr);
 
-        if (s.substr(ptr, s.length()-ptr-1) == "")
+        if (s.substr(ptr, s.length()-ptr-1).empty())
             return Value();
     }
 
 
-    if (s == "") {
+    if (s.empty()) {
         return Value();
     } else if (s[ptr] == '\'') {
         // If this is a quote
@@ -1157,7 +1157,7 @@ namespace builtin {
         // Is not a special form, so we can evaluate our args.
         eval_args(args, env);
 
-        std::exit(args.size() < 1? 0 : args[0].cast_to_int().as_int());
+        std::exit(args.empty()? 0 : args[0].cast_to_int().as_int());
         return Value();
     }
 
@@ -1166,7 +1166,7 @@ namespace builtin {
         // Is not a special form, so we can evaluate our args.
         eval_args(args, env);
 
-        if (args.size() < 1)
+        if (args.empty())
             throw Error(Value("print", print), env, TOO_FEW_ARGS);
 
         Value acc;
@@ -1488,7 +1488,7 @@ namespace builtin {
         // Is not a special form, so we can evaluate our args.
         eval_args(args, env);
 
-        if (args.size() == 0)
+        if (args.empty())
             throw Error(Value("push", push), env, TOO_FEW_ARGS);
         for (size_t i=1; i<args.size(); i++)
             args[0].push(args[i]);
@@ -1664,7 +1664,7 @@ void repl(Environment &env) {
             f.open(input.c_str(), std::ofstream::out);
             f << code;
             f.close();
-        } else if (input != "") {
+        } else if (!input.empty()) {
             try {
                 tmp = run(input, env);
                 std::cout << " => " << tmp.debug() << std::endl;


### PR DESCRIPTION
- parameters copied for each invocation but used as `const` references; refactored into `const` references
- use `nullptr`
- use range-based `for` loops
- use `empty` method whenever possible